### PR TITLE
Develop

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -70,8 +70,6 @@ Website(
     environment=environment,
     website_certificate=certificates.website_certificate.certificate,
     contact_form_certificate=certificates.contact_form_certificate.certificate,
-    backup_bucket_name=backup_bucket_stack.bucket_name,
-    backup_bucket_arn=backup_bucket_stack.bucket_arn,
     env=env,
     cross_region_references=True,
     description="Stack to deploy the website resources",

--- a/src/app.py
+++ b/src/app.py
@@ -70,6 +70,7 @@ Website(
     environment=environment,
     website_certificate=certificates.website_certificate.certificate,
     contact_form_certificate=certificates.contact_form_certificate.certificate,
+    cloudfront_env=cloudfront_env,
     env=env,
     cross_region_references=True,
     description="Stack to deploy the website resources",

--- a/src/assets/lambda/contact_form_intake/contact_form_intake.py
+++ b/src/assets/lambda/contact_form_intake/contact_form_intake.py
@@ -107,7 +107,7 @@ def send_email(customer_email, customer_message):
 
     ses.send_email(
         Source=f"noreply@{domain}",
-        Destination={"ToAddresses": ["cullan@cullancarey.com"]},
+        Destination={"ToAddresses": ["cullancareyconsulting@gmail.com"]},
         Message={
             "Subject": {"Data": subject},
             "Body": {

--- a/src/assets/lambda/ssm_param_replicator/Dockerfile
+++ b/src/assets/lambda/ssm_param_replicator/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/lambda/python:3.11
+
+# Copy function code
+COPY ssm_param_replicator.py ${LAMBDA_TASK_ROOT}
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "ssm_param_replicator.lambda_handler" ]

--- a/src/assets/lambda/ssm_param_replicator/ssm_param_replicator.py
+++ b/src/assets/lambda/ssm_param_replicator/ssm_param_replicator.py
@@ -1,0 +1,55 @@
+import boto3
+import os
+import json
+import urllib.request
+
+
+def send_cfn_response(event, context, status, reason=None, data=None):
+    response_body = {
+        "Status": status,
+        "Reason": reason
+        or f"See the details in CloudWatch Log Stream: {context.log_stream_name}",
+        "PhysicalResourceId": context.log_stream_name,
+        "StackId": event["StackId"],
+        "RequestId": event["RequestId"],
+        "LogicalResourceId": event["LogicalResourceId"],
+        "Data": data or {},
+    }
+
+    json_response_body = json.dumps(response_body)
+    headers = {"content-type": "", "content-length": str(len(json_response_body))}
+
+    try:
+        request = urllib.request.Request(
+            url=event["ResponseURL"],
+            data=json_response_body.encode("utf-8"),
+            headers=headers,
+            method="PUT",
+        )
+        with urllib.request.urlopen(request) as response:
+            print(f"CFN response status: {response.status}, reason: {response.reason}")
+    except Exception as e:
+        print(f"Failed to send CFN response: {e}")
+
+
+def lambda_handler(event, context):
+    print("Received event:", json.dumps(event))
+    ssm_src = boto3.client("ssm", region_name=os.environ["SOURCE_REGION"])
+    ssm_dst = boto3.client("ssm", region_name=os.environ["TARGET_REGION"])
+
+    try:
+        parameters = json.loads(os.environ["PARAMETERS"])
+        for param in parameters:
+            response = ssm_src.get_parameter(Name=param["source"])
+            ssm_dst.put_parameter(
+                Name=param["target"],
+                Value=response["Parameter"]["Value"],
+                Type="String",
+                Overwrite=True,
+            )
+        send_cfn_response(
+            event, context, status="SUCCESS", data={"Message": "Replication complete"}
+        )
+    except Exception as e:
+        print(f"Error replicating parameters: {e}")
+        send_cfn_response(event, context, status="FAILED", reason=str(e))

--- a/src/cdk.context.json
+++ b/src/cdk.context.json
@@ -3,13 +3,31 @@
     "account_id": "693590665244",
     "region": "us-east-2",
     "domain_name": "develop.cullancarey.com",
-    "file_path": "main"
+    "file_path": "main",
+    "acm_ssm_params": {
+      "website_cert_arn_param": "/ACMCertificates/WebsiteCertificateArn",
+      "contact_form_cert_arn_param": "/ACMCertificates/ContactFormCertificateArn"
+    },
+    "backup_website_bucket_ssm_params": {
+      "backup_website_bucket_arn_param": "/BackupWebsiteBucket/BackupWebsiteBucketArn",
+      "backup_website_bucket_domain_name_param": "/BackupWebsiteBucket/BackupWebsiteBucketDomainName",
+      "backup_website_bucket_name_param": "/BackupWebsiteBucket/BackupWebsiteBucketName"
+    }
   },
   "production": {
     "account_id": "045107234435",
     "region": "us-east-2",
     "domain_name": "cullancarey.com",
-    "file_path": "main"
+    "file_path": "main",
+    "acm_ssm_params": {
+      "website_cert_arn_param": "/ACMCertificates/WebsiteCertificateArn",
+      "contact_form_cert_arn_param": "/ACMCertificates/ContactFormCertificateArn"
+    },
+    "backup_website_bucket_ssm_params": {
+      "backup_website_bucket_arn_param": "/BackupWebsiteBucket/BackupWebsiteBucketArn",
+      "backup_website_bucket_domain_name_param": "/BackupWebsiteBucket/BackupWebsiteBucketDomainName",
+      "backup_website_bucket_name_param": "/BackupWebsiteBucket/BackupWebsiteBucketName"
+    }
   },
   "hosted-zone:account=693590665244:domainName=develop.cullancarey.com:region=us-east-2": {
     "Id": "/hostedzone/Z081077825HU0N2Q4H1ZC",

--- a/src/main/assets/js/contact-form.js
+++ b/src/main/assets/js/contact-form.js
@@ -44,7 +44,7 @@ async function submitForm() {
         if (response.ok) {  // response.ok means 200-299
             alert((data.message || 'Thank you for your message!'));
         } else {
-            alert((data.error || 'Something went wrong. Please contact cullan@cullancarey.com.'));
+            alert((data.error || 'Something went wrong. Please contact cullancareyconsulting@gmail.com.'));
         }
     } catch (error) {
         console.error("There was a problem with the fetch operation:", error);

--- a/src/main/index.html
+++ b/src/main/index.html
@@ -102,7 +102,7 @@
 							<li><span class="first-block">Personal Email:</span><span
 									class="second-block">cullancarey@gmail.com</span></li>
 							<li><span class="first-block">Business Email:</span><span
-									class="second-block">cullan@cullancarey.com</span></li>
+									class="second-block">cullancareyconsulting@gmail.com</span></li>
 							<li><span class="first-block">Location:</span><span class="second-block">Indianapolis,
 									IN</span></li>
 						</ul>

--- a/src/my_constructs/apigw_to_lambda.py
+++ b/src/my_constructs/apigw_to_lambda.py
@@ -100,7 +100,6 @@ class ApiGwtoLambda(Construct):
                 f"arn:aws:ses:us-east-2:{account_id}:identity/{domain_name.replace('form.', '')}",
                 f"arn:aws:ses:us-east-2:{account_id}:identity/cullancarey@yahoo.com",
                 f"arn:aws:ses:us-east-2:{account_id}:identity/cullancareyconsulting@gmail.com",
-                f"arn:aws:ses:us-east-2:{account_id}:identity/cullan@cullancarey.com",
                 f"arn:aws:ses:us-east-2:{account_id}:configuration-set/cullancarey",
             ],
         )

--- a/src/my_constructs/cloudfront_distribution.py
+++ b/src/my_constructs/cloudfront_distribution.py
@@ -29,34 +29,17 @@ class CloudfrontDistribution(Construct):
     ) -> None:
         super().__init__(scope, id, **kwargs)
 
-        backup_bucket_param = ssm.StringParameter.from_string_parameter_attributes(
-            self,
-            "BackupBucketNameParam",
-            parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketName",
-            simple_name=False,
-            region=cloudfront_env.region,
+        backup_bucket_name = ssm.StringParameter.value_for_string_parameter(
+            self, parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketName"
         )
 
-        backup_bucket_arn_param = ssm.StringParameter.from_string_parameter_attributes(
-            self,
-            "BackupBucketArnParam",
-            parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketArn",
-            simple_name=False,
-            region=cloudfront_env.region,
+        backup_bucket_arn = ssm.StringParameter.value_for_string_parameter(
+            self, parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketArn"
         )
 
-        backup_bucket_domain_param = (
-            ssm.StringParameter.from_string_parameter_attributes(
-                self,
-                "BackupBucketDomainNameParam",
-                parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketDomainName",
-                simple_name=False,
-                region=cloudfront_env.region,
-            )
+        backup_bucket_domain_name = ssm.StringParameter.value_for_string_parameter(
+            self, parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketDomainName"
         )
-        backup_bucket_name = backup_bucket_param.string_value
-        backup_bucket_arn = backup_bucket_arn_param.string_value
-        backup_bucket_domain_name = backup_bucket_domain_param.string_value
 
         if origin_type == "s3":
             cf_oac = cloudfront.CfnOriginAccessControl(

--- a/src/my_constructs/cloudfront_distribution.py
+++ b/src/my_constructs/cloudfront_distribution.py
@@ -27,13 +27,13 @@ class CloudfrontDistribution(Construct):
     ) -> None:
         super().__init__(scope, id, **kwargs)
 
-        backup_bucket_name_param = ssm.StringParameter.from_string_parameter_attributes(
+        backup_bucket_param = ssm.StringParameter.from_string_parameter_attributes(
             self,
             "BackupBucketNameParam",
             parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketName",
-            simple_name=False,
+            region="us-east-1",
         )
-        backup_bucket_name = backup_bucket_name_param.string_value
+        backup_bucket_name = backup_bucket_param.string_value
 
         if origin_type == "s3":
             cf_oac = cloudfront.CfnOriginAccessControl(

--- a/src/my_constructs/cloudfront_distribution.py
+++ b/src/my_constructs/cloudfront_distribution.py
@@ -7,6 +7,7 @@ from aws_cdk import (
     RemovalPolicy,
     Aws,
     Duration,
+    Environment,
 )
 from aws_cdk.aws_cloudfront_origins import S3BucketOrigin, HttpOrigin, OriginGroup
 from aws_cdk.aws_cloudfront import HeadersFrameOption, HeadersReferrerPolicy
@@ -21,6 +22,7 @@ class CloudfrontDistribution(Construct):
         domain_name: str,
         origin_type: str,
         certificate: acm.Certificate,
+        cloudfront_env: Environment,
         website_s3_bucket: s3.IBucket = None,
         api_gateway: apigw.CfnApi = None,
         **kwargs,
@@ -31,7 +33,8 @@ class CloudfrontDistribution(Construct):
             self,
             "BackupBucketNameParam",
             parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketName",
-            region="us-east-1",
+            simple_name=False,
+            env=cloudfront_env,
         )
         backup_bucket_name = backup_bucket_param.string_value
 

--- a/src/my_constructs/cloudfront_distribution.py
+++ b/src/my_constructs/cloudfront_distribution.py
@@ -22,24 +22,24 @@ class CloudfrontDistribution(Construct):
         domain_name: str,
         origin_type: str,
         certificate: acm.Certificate,
-        cloudfront_env: Environment,
+        backup_bucket_name: str = None,
         website_s3_bucket: s3.IBucket = None,
         api_gateway: apigw.CfnApi = None,
         **kwargs,
     ) -> None:
         super().__init__(scope, id, **kwargs)
 
-        backup_bucket_name = ssm.StringParameter.value_for_string_parameter(
-            self, parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketName"
-        )
+        # backup_bucket_name = ssm.StringParameter.value_for_string_parameter(
+        #     self, parameter_name=backup_ssm_param_names["name"]
+        # )
 
-        backup_bucket_arn = ssm.StringParameter.value_for_string_parameter(
-            self, parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketArn"
-        )
+        # backup_bucket_arn = ssm.StringParameter.value_for_string_parameter(
+        #     self, parameter_name=backup_ssm_param_names["arn"]
+        # )
 
-        backup_bucket_domain_name = ssm.StringParameter.value_for_string_parameter(
-            self, parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketDomainName"
-        )
+        # backup_bucket_domain_name = ssm.StringParameter.value_for_string_parameter(
+        #     self, parameter_name=backup_ssm_param_names["domain"]
+        # )
 
         if origin_type == "s3":
             cf_oac = cloudfront.CfnOriginAccessControl(
@@ -154,7 +154,6 @@ class CloudfrontDistribution(Construct):
             self.cf_distribution.apply_removal_policy(RemovalPolicy.DESTROY)
 
             cfn_website_distribution = self.cf_distribution.node.default_child
-            # Apply OAC to the primary origin (Origins[0])
             cfn_website_distribution.add_property_override(
                 "DistributionConfig.Origins.0.OriginAccessControlId",
                 cf_oac.get_att("Id"),
@@ -163,8 +162,6 @@ class CloudfrontDistribution(Construct):
                 "DistributionConfig.Origins.0.S3OriginConfig.OriginAccessIdentity",
                 "",
             )
-
-            # Apply OAC to the backup origin (Origins[1])
             cfn_website_distribution.add_property_override(
                 "DistributionConfig.Origins.1.OriginAccessControlId",
                 cf_oac.get_att("Id"),
@@ -173,6 +170,7 @@ class CloudfrontDistribution(Construct):
                 "DistributionConfig.Origins.1.S3OriginConfig.OriginAccessIdentity",
                 "",
             )
+
         if origin_type == "http":
             response_headers_policy = cloudfront.ResponseHeadersPolicy(
                 self,
@@ -187,7 +185,6 @@ class CloudfrontDistribution(Construct):
                 ),
             )
 
-            # CloudFront Distribution for API Gateway
             self.cf_distribution = cloudfront.Distribution(
                 self,
                 f"ContactFormIntakeDistribution",

--- a/src/my_constructs/cloudfront_distribution.py
+++ b/src/my_constructs/cloudfront_distribution.py
@@ -31,7 +31,7 @@ class CloudfrontDistribution(Construct):
             self,
             "BackupBucketNameParam",
             parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketName",
-            region="us-east-1",
+            simple_name=False,
         )
         backup_bucket_name = backup_bucket_name_param.string_value
 

--- a/src/my_constructs/cloudfront_distribution.py
+++ b/src/my_constructs/cloudfront_distribution.py
@@ -38,6 +38,26 @@ class CloudfrontDistribution(Construct):
         )
         backup_bucket_name = backup_bucket_param.string_value
 
+        backup_bucket_arn_param = ssm.StringParameter.from_string_parameter_attributes(
+            self,
+            "BackupBucketArnParam",
+            parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketArn",
+            simple_name=False,
+            env=cloudfront_env,
+        )
+        backup_bucket_arn = backup_bucket_arn_param.string_value
+
+        backup_bucket_domain_param = (
+            ssm.StringParameter.from_string_parameter_attributes(
+                self,
+                "BackupBucketDomainNameParam",
+                parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketDomainName",
+                simple_name=False,
+                env=cloudfront_env,
+            )
+        )
+        backup_bucket_domain_name = backup_bucket_domain_param.string_value
+
         if origin_type == "s3":
             cf_oac = cloudfront.CfnOriginAccessControl(
                 self,

--- a/src/my_constructs/cloudfront_distribution.py
+++ b/src/my_constructs/cloudfront_distribution.py
@@ -34,18 +34,16 @@ class CloudfrontDistribution(Construct):
             "BackupBucketNameParam",
             parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketName",
             simple_name=False,
-            env=cloudfront_env,
+            region=cloudfront_env.region,
         )
-        backup_bucket_name = backup_bucket_param.string_value
 
         backup_bucket_arn_param = ssm.StringParameter.from_string_parameter_attributes(
             self,
             "BackupBucketArnParam",
             parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketArn",
             simple_name=False,
-            env=cloudfront_env,
+            region=cloudfront_env.region,
         )
-        backup_bucket_arn = backup_bucket_arn_param.string_value
 
         backup_bucket_domain_param = (
             ssm.StringParameter.from_string_parameter_attributes(
@@ -53,9 +51,11 @@ class CloudfrontDistribution(Construct):
                 "BackupBucketDomainNameParam",
                 parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketDomainName",
                 simple_name=False,
-                env=cloudfront_env,
+                region=cloudfront_env.region,
             )
         )
+        backup_bucket_name = backup_bucket_param.string_value
+        backup_bucket_arn = backup_bucket_arn_param.string_value
         backup_bucket_domain_name = backup_bucket_domain_param.string_value
 
         if origin_type == "s3":

--- a/src/my_constructs/ssm_param_replicator.py
+++ b/src/my_constructs/ssm_param_replicator.py
@@ -1,0 +1,65 @@
+from aws_cdk import (
+    Duration,
+    aws_lambda as _lambda,
+    custom_resources as cr,
+    aws_logs as logs,
+    aws_iam as iam,
+    CustomResource,
+)
+from constructs import Construct
+import json
+
+
+class SsmParameterReplicator(Construct):
+    def __init__(
+        self,
+        scope: Construct,
+        id: str,
+        source_region: str,
+        target_region: str,
+        parameters: list,
+        **kwargs,
+    ) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        replicate_ssm_lambda = _lambda.DockerImageFunction(
+            self,
+            "SSMParamReplicatorLambda",
+            code=_lambda.DockerImageCode.from_image_asset(
+                "assets/lambda/ssm_param_replicator/"
+            ),
+            timeout=Duration.seconds(60),
+            architecture=_lambda.Architecture.X86_64,
+            environment={
+                "SOURCE_REGION": source_region,
+                "TARGET_REGION": target_region,
+                "PARAMETERS": json.dumps(parameters),
+            },
+            log_retention=logs.RetentionDays.ONE_YEAR,
+        )
+
+        replicate_ssm_lambda.add_to_role_policy(
+            iam.PolicyStatement(
+                actions=["ssm:GetParameter"],
+                resources=[f"arn:aws:ssm:{source_region}:{scope.account}:parameter/*"],
+            )
+        )
+
+        replicate_ssm_lambda.add_to_role_policy(
+            iam.PolicyStatement(
+                actions=["ssm:PutParameter"],
+                resources=[f"arn:aws:ssm:{target_region}:{scope.account}:parameter/*"],
+            )
+        )
+
+        provider = cr.Provider(
+            self,
+            "ReplicateSSMProvider",
+            on_event_handler=replicate_ssm_lambda,
+        )
+
+        CustomResource(
+            self,
+            "ReplicateSSMCustomResource",
+            service_token=provider.service_token,
+        )

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib
-constructs
+aws-cdk-lib>=2.137.0
+constructs>=10.3.0

--- a/src/stacks/acm_certificates_stack.py
+++ b/src/stacks/acm_certificates_stack.py
@@ -1,32 +1,69 @@
-from aws_cdk import Stack, aws_route53 as route53
+from aws_cdk import Stack, aws_route53 as route53, aws_ssm as ssm
 from constructs import Construct
 from my_constructs.acm_certificate import AcmCertificate
+from my_constructs.ssm_param_replicator import SsmParameterReplicator
 
 
 class ACMCertificates(Stack):
     def __init__(
-        self, scope: Construct, id: str, account_id: str, domain_name: str, **kwargs
+        self,
+        scope: Construct,
+        id: str,
+        account_id: str,
+        domain_name: str,
+        env_region: str,
+        ssm_params: dict,
+        **kwargs,
     ) -> None:
         super().__init__(scope, id, **kwargs)
 
-        _hosted_zone = route53.HostedZone.from_lookup(
+        hosted_zone = route53.HostedZone.from_lookup(
             self, f"{id}-HostedZone", domain_name=domain_name
         )
 
-        _contact_form_domain_name = f"form.{domain_name}"
-
-        self.website_certificate = AcmCertificate(
+        website_cert = AcmCertificate(
             self,
             "WebsiteCertificate",
             account_id=account_id,
             domain_name=domain_name,
-            hosted_zone=_hosted_zone,
+            hosted_zone=hosted_zone,
         )
 
-        self.contact_form_certificate = AcmCertificate(
+        contact_form_cert = AcmCertificate(
             self,
             "ContactFormCertificate",
             account_id=account_id,
-            domain_name=_contact_form_domain_name,
-            hosted_zone=_hosted_zone,
+            domain_name=f"form.{domain_name}",
+            hosted_zone=hosted_zone,
+        )
+
+        website_cert_arn_param = ssm.StringParameter(
+            self,
+            "WebsiteCertArnParam",
+            parameter_name=ssm_params["website_cert_arn_param"],
+            string_value=website_cert.certificate.certificate_arn,
+        )
+
+        contact_form_cert_arn_param = ssm.StringParameter(
+            self,
+            "ContactFormCertArnParam",
+            parameter_name=ssm_params["contact_form_cert_arn_param"],
+            string_value=contact_form_cert.certificate.certificate_arn,
+        )
+
+        SsmParameterReplicator(
+            self,
+            "ACMCertsSSMReplicator",
+            source_region=env_region,
+            target_region="us-east-2",
+            parameters=[
+                {
+                    "source": website_cert_arn_param.parameter_name,
+                    "target": website_cert_arn_param.parameter_name,
+                },
+                {
+                    "source": contact_form_cert_arn_param.parameter_name,
+                    "target": contact_form_cert_arn_param.parameter_name,
+                },
+            ],
         )

--- a/src/stacks/backup_website_bucket.py
+++ b/src/stacks/backup_website_bucket.py
@@ -24,7 +24,7 @@ class BackupWebsiteBucket(Stack):
         ssm.StringParameter(
             self,
             "BackupBucketArnParam",
-            parameter_name=f"/{website_stack_name}/BackupWebsiteBucketArn",
+            parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketArn",
             string_value=bucket_arn,
         )
 
@@ -32,7 +32,7 @@ class BackupWebsiteBucket(Stack):
         ssm.StringParameter(
             self,
             "BackupBucketDomainNameParam",
-            parameter_name=f"/{website_stack_name}/BackupWebsiteBucketDomainName",
+            parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketDomainName",
             string_value=bucket_domain_name,
         )
 
@@ -40,6 +40,6 @@ class BackupWebsiteBucket(Stack):
         ssm.StringParameter(
             self,
             "BackupBucketNameParam",
-            parameter_name=f"/{website_stack_name}/BackupWebsiteBucketName",
+            parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketName",
             string_value=bucket_name,
         )

--- a/src/stacks/backup_website_bucket.py
+++ b/src/stacks/backup_website_bucket.py
@@ -1,45 +1,67 @@
-from aws_cdk import Stack, aws_ssm as ssm
+from aws_cdk import (
+    Stack,
+    aws_ssm as ssm,
+)
 from constructs import Construct
 from my_constructs.s3_bucket import S3Bucket
+from my_constructs.ssm_param_replicator import SsmParameterReplicator
 
 
 class BackupWebsiteBucket(Stack):
-    def __init__(self, scope: Construct, id: str, **kwargs) -> None:
+    def __init__(
+        self, scope: Construct, id: str, ssm_params: dict, region: str, **kwargs
+    ) -> None:
         super().__init__(scope, id, **kwargs)
 
         # Define your bucket
         self.backup_website_bucket = S3Bucket(self, "BackupWebsiteBucket")
 
-        # Expose bucket_name, arn, and domain_name
         bucket_name = self.backup_website_bucket.bucket.bucket_name
         bucket_arn = self.backup_website_bucket.bucket.bucket_arn
         bucket_domain_name = (
             self.backup_website_bucket.bucket.bucket_regional_domain_name
         )
 
-        # Define website_stack_name explicitly
-        website_stack_name = self.stack_name
-
-        # Write Bucket ARN to SSM
-        ssm.StringParameter(
+        # Write parameters to SSM (in the stack's region)
+        bucket_arn_param = ssm.StringParameter(
             self,
             "BackupBucketArnParam",
-            parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketArn",
+            parameter_name=ssm_params["backup_website_bucket_arn_param"],
             string_value=bucket_arn,
         )
 
-        # Write Bucket Domain Name to SSM
-        ssm.StringParameter(
+        bucket_domain_name_param = ssm.StringParameter(
             self,
             "BackupBucketDomainNameParam",
-            parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketDomainName",
+            parameter_name=ssm_params["backup_website_bucket_domain_name_param"],
             string_value=bucket_domain_name,
         )
 
-        # Write Bucket Name to SSM
-        ssm.StringParameter(
+        bucket_name_param = ssm.StringParameter(
             self,
             "BackupBucketNameParam",
-            parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketName",
+            parameter_name=ssm_params["backup_website_bucket_name_param"],
             string_value=bucket_name,
+        )
+
+        # Replicate these parameters to another region (us-east-2)
+        SsmParameterReplicator(
+            self,
+            "BackupBucketSSMReplicator",
+            source_region=region,
+            target_region="us-east-2",
+            parameters=[
+                {
+                    "source": bucket_arn_param.parameter_name,
+                    "target": bucket_arn_param.parameter_name,
+                },
+                {
+                    "source": bucket_domain_name_param.parameter_name,
+                    "target": bucket_domain_name_param.parameter_name,
+                },
+                {
+                    "source": bucket_name_param.parameter_name,
+                    "target": bucket_name_param.parameter_name,
+                },
+            ],
         )

--- a/src/stacks/backup_website_bucket.py
+++ b/src/stacks/backup_website_bucket.py
@@ -1,4 +1,4 @@
-from aws_cdk import Stack
+from aws_cdk import Stack, aws_ssm as ssm
 from constructs import Construct
 from my_constructs.s3_bucket import S3Bucket
 
@@ -7,8 +7,39 @@ class BackupWebsiteBucket(Stack):
     def __init__(self, scope: Construct, id: str, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
 
+        # Define your bucket
         self.backup_website_bucket = S3Bucket(self, "BackupWebsiteBucket")
 
-        # Expose bucket_name and bucket_arn for use in app.py
-        self.bucket_name = self.backup_website_bucket.bucket.bucket_name
-        self.bucket_arn = self.backup_website_bucket.bucket.bucket_arn
+        # Expose bucket_name, arn, and domain_name
+        bucket_name = self.backup_website_bucket.bucket.bucket_name
+        bucket_arn = self.backup_website_bucket.bucket.bucket_arn
+        bucket_domain_name = (
+            self.backup_website_bucket.bucket.bucket_regional_domain_name
+        )
+
+        # Define website_stack_name explicitly
+        website_stack_name = self.stack_name
+
+        # Write Bucket ARN to SSM
+        ssm.StringParameter(
+            self,
+            "BackupBucketArnParam",
+            parameter_name=f"/{website_stack_name}/BackupWebsiteBucketArn",
+            string_value=bucket_arn,
+        )
+
+        # Write Bucket Domain Name to SSM
+        ssm.StringParameter(
+            self,
+            "BackupBucketDomainNameParam",
+            parameter_name=f"/{website_stack_name}/BackupWebsiteBucketDomainName",
+            string_value=bucket_domain_name,
+        )
+
+        # Write Bucket Name to SSM
+        ssm.StringParameter(
+            self,
+            "BackupBucketNameParam",
+            parameter_name=f"/{website_stack_name}/BackupWebsiteBucketName",
+            string_value=bucket_name,
+        )

--- a/src/stacks/website_stack.py
+++ b/src/stacks/website_stack.py
@@ -1,5 +1,6 @@
 from aws_cdk import (
     Stack,
+    Environment,
     aws_s3 as s3,
     aws_cloudfront as cloudfront,
     aws_route53 as route53,
@@ -28,6 +29,7 @@ class Website(Stack):
         environment: str,
         website_certificate: acm.Certificate,
         contact_form_certificate: acm.Certificate,
+        cloudfront_env: Environment,
         **kwargs,
     ) -> None:
         super().__init__(scope, id, **kwargs)
@@ -65,6 +67,7 @@ class Website(Stack):
             origin_type="s3",
             certificate=website_certificate,
             website_s3_bucket=website_bucket.bucket,
+            cloudfront_env=cloudfront_env,
         )
 
         website_bucket_policy_statement = iam.PolicyStatement(

--- a/src/stacks/website_stack.py
+++ b/src/stacks/website_stack.py
@@ -42,7 +42,7 @@ class Website(Stack):
             self,
             "BackupBucketArnParam",
             parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketArn",
-            region="us-east-1",
+            simple_name=False,
         )
         backup_bucket_arn = backup_bucket_arn_param.string_value
 
@@ -50,7 +50,7 @@ class Website(Stack):
             self,
             "BackupBucketNameParam",
             parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketName",
-            region="us-east-1",
+            simple_name=False,
         )
         backup_bucket_name = backup_bucket_name_param.string_value
 

--- a/src/stacks/website_stack.py
+++ b/src/stacks/website_stack.py
@@ -131,6 +131,7 @@ class Website(Stack):
             origin_type="http",
             certificate=contact_form_certificate,
             api_gateway=apigw.contact_form_api,
+            cloudfront_env=cloudfront_env,  # ✅ Add this
         )
 
         _add_route53_record(

--- a/src/stacks/website_stack.py
+++ b/src/stacks/website_stack.py
@@ -37,22 +37,13 @@ class Website(Stack):
         )
         _contact_form_domain_name = f"form.{domain_name}"
 
-        # ✅ Use from_string_parameter_attributes to avoid Fn::ImportValue and allow cross-region reads
-        backup_bucket_arn_param = ssm.StringParameter.from_string_parameter_attributes(
-            self,
-            "BackupBucketArnParam",
-            parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketArn",
-            simple_name=False,
+        backup_bucket_arn = ssm.StringParameter.value_for_string_parameter(
+            self, "/BackupWebsiteBucket/BackupWebsiteBucketArn"
         )
-        backup_bucket_arn = backup_bucket_arn_param.string_value
 
-        backup_bucket_name_param = ssm.StringParameter.from_string_parameter_attributes(
-            self,
-            "BackupBucketNameParam",
-            parameter_name="/BackupWebsiteBucket/BackupWebsiteBucketName",
-            simple_name=False,
+        backup_bucket_name = ssm.StringParameter.value_for_string_parameter(
+            self, "/BackupWebsiteBucket/BackupWebsiteBucketName"
         )
-        backup_bucket_name = backup_bucket_name_param.string_value
 
         def _add_route53_record(record_name: str, cf_dist: cloudfront.Distribution):
             route53.ARecord(


### PR DESCRIPTION
This pull request introduces several updates to enhance infrastructure management, improve maintainability, and update configurations. Key changes include refactoring the `add_tags` function, introducing a new Lambda-based SSM parameter replication construct, and updating email addresses across the application.

### Infrastructure Enhancements:
* Refactored the `add_tags` function to simplify its parameters and ensure tags are applied consistently to the `stack` object. Removed support for `app` tagging. (`src/app.py`, [src/app.pyL9-R11](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00L9-R11))
* Added a new `SsmParameterReplicator` construct for replicating SSM parameters between AWS regions using a Lambda function. This includes the Lambda code (`ssm_param_replicator.py`) and its Dockerfile. (`src/assets/lambda/ssm_param_replicator/Dockerfile`, [[1]](diffhunk://#diff-7e5d3623d7d7e96d4a03a7e95ba2420fdee376c2edbc3f3059727cab4180da9aR1-R7); `src/assets/lambda/ssm_param_replicator/ssm_param_replicator.py`, [[2]](diffhunk://#diff-a03e1c29c68851779f7bb21f972227e82f409aed4ea241ce3d75e05843bf55d1R1-R55); `src/my_constructs/ssm_param_replicator.py`, [[3]](diffhunk://#diff-f088eba220d5a9f1b85373230183a13482863ae91923560daf30a6fb0d6b207cR1-R65)
* Updated the ACM certificates stack to store certificate ARNs in SSM parameters and replicate them across regions using the new `SsmParameterReplicator`. (`src/stacks/acm_certificates_stack.py`, [src/stacks/acm_certificates_stack.pyL1-R68](diffhunk://#diff-e35617b9e3538dbaa4b8afc4fbddf5e34fcb7a9a30fe659f67b5798a362f5326L1-R68))

### Configuration and Parameter Updates:
* Updated `cdk.context.json` to include new SSM parameter configurations for ACM certificates and the backup website bucket. (`src/cdk.context.json`, [src/cdk.context.jsonL6-R30](diffhunk://#diff-698dceefafbef210d002464d1059d20a091a49a0e2ad663e7897e091690bfb1cL6-R30))
* Changed `environment_config` lookups to use dictionary key access instead of `get()` for stricter error handling. (`src/app.py`, [src/app.pyL28-R33](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00L28-R33))

### Email Address Updates:
* Replaced the old email address `cullan@cullancarey.com` with `cullancareyconsulting@gmail.com` across multiple files, including SES configurations, contact form handlers, and the website's "About Me" section. (`src/assets/lambda/contact_form_intake/contact_form_intake.py`, [[1]](diffhunk://#diff-20079ec81ca2c743c8d7297c873a8c45d1df0225cbffdedd5ec77b211fdb6f25L110-R110); `src/main/assets/js/contact-form.js`, [[2]](diffhunk://#diff-8c31a3368ad32695a5d0954475173ac53db16f241d0e540e903f3c9c8dfbb948L47-R47); `src/main/index.html`, [[3]](diffhunk://#diff-71de25da3da11ba38d686984339376790e6439940511fd487cea04fbb0806256L105-R105); `src/my_constructs/apigw_to_lambda.py`, [[4]](diffhunk://#diff-02f5177f64d7aeb6bfa0da84d6a082ff2300b3baf5feddbb2263f765464ce128L103)

### Miscellaneous Updates:
* Updated dependencies in `requirements.txt` to specify minimum versions for `aws-cdk-lib` and `constructs`. (`src/requirements.txt`, [src/requirements.txtL1-R2](diffhunk://#diff-0a0827574cc2d3aac80f74096dd6d1e871b83efae03aa087c2c8e8f1e9187d26L1-R2))
* Refactored and cleaned up the CloudFront distribution construct to prepare for future SSM parameter integration. (`src/my_constructs/cloudfront_distribution.py`, [[1]](diffhunk://#diff-cd93968b0837e8ea172e47f1a947a90a5368c481a9a18e2ea836aa0715e03a9cR6-R10) [[2]](diffhunk://#diff-cd93968b0837e8ea172e47f1a947a90a5368c481a9a18e2ea836aa0715e03a9cL23-R43) [[3]](diffhunk://#diff-cd93968b0837e8ea172e47f1a947a90a5368c481a9a18e2ea836aa0715e03a9cL113-R127) [[4]](diffhunk://#diff-cd93968b0837e8ea172e47f1a947a90a5368c481a9a18e2ea836aa0715e03a9cL143) [[5]](diffhunk://#diff-cd93968b0837e8ea172e47f1a947a90a5368c481a9a18e2ea836aa0715e03a9cL152-L153) [[6]](diffhunk://#diff-cd93968b0837e8ea172e47f1a947a90a5368c481a9a18e2ea836aa0715e03a9cR173) [[7]](diffhunk://#diff-cd93968b0837e8ea172e47f1a947a90a5368c481a9a18e2ea836aa0715e03a9cL176)