### PR TITLE
Update Dockerfiles to use Python 3.13 and enhance requirements.txt 

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,6 +7,7 @@ ENV ?= development
 
 install-deps:
 	npm install -g aws-cdk
+	pip install --upgrade pip
 	pip install --upgrade -r requirements.txt
 
 cdk-version:

--- a/src/assets/lambdas/contact_form_intake/Dockerfile
+++ b/src/assets/lambdas/contact_form_intake/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.11
+FROM public.ecr.aws/lambda/python:3.13
 
 # Copy function code
 COPY contact_form_intake.py ${LAMBDA_TASK_ROOT}

--- a/src/assets/lambdas/ssm_param_replicator/Dockerfile
+++ b/src/assets/lambdas/ssm_param_replicator/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.11
+FROM public.ecr.aws/lambda/python:3.13
 
 # Copy function code
 COPY ssm_param_replicator.py ${LAMBDA_TASK_ROOT}

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,4 @@
 aws-cdk-lib
 constructs
+cfn-lint
+pytest


### PR DESCRIPTION
This pull request introduces several updates to the development and deployment environment, primarily focusing on upgrading Python versions for Lambda functions and improving dependency management. These changes help ensure compatibility with newer Python features and streamline the setup process for local development and testing.

**Environment and Dependency Management:**

* Added `cfn-lint` and `pytest` to `requirements.txt` to support CloudFormation template linting and Python testing.
* Updated the `install-deps` step in the `Makefile` to upgrade `pip` before installing requirements, ensuring the latest package management capabilities.

**Lambda Runtime Upgrades:**

* Changed the base image for the `contact_form_intake` Lambda Dockerfile from Python 3.11 to Python 3.13, enabling use of newer language features and improved runtime performance.
* Changed the base image for the `ssm_param_replicator` Lambda Dockerfile from Python 3.11 to Python 3.13 for consistency and modernization.